### PR TITLE
Update heapster_influxdb image & point to gcr.io

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-grafana-controller.yaml
+++ b/deploy/kube-config/influxdb/influxdb-grafana-controller.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: kubernetes/heapster_influxdb:v0.5
+        image: gcr.io/google_containers/heapster_influxdb:v0.7
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage


### PR DESCRIPTION
- influxdb switched DB engines between 0.9 (available in 0.5 of the heapster_influxdb image) and 0.11 (available in 0.7). IOPs consumed went from 600+ to < 20 as a result of the image change.
- should probably be pulling all images from gcr.io instead of docker hub
